### PR TITLE
Soften the Jekyll dependency for the upcoming 3.0 version.

### DIFF
--- a/jekyll-assets.gemspec
+++ b/jekyll-assets.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(/^(test|spec|features)\//)
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "jekyll",       "~> 2.0"
+  spec.add_dependency "jekyll",       ">= 2"
   spec.add_dependency "sass",         "~> 3.2"
   spec.add_dependency "fastimage",    "~> 1.6"
   spec.add_dependency "mini_magick",  "~> 4.1"


### PR DESCRIPTION
The current dependency specified in the gem is 2.x.x. But with the upcoming 3.0 version, I believe the dependency should be loosened.